### PR TITLE
Add error handling for floating point numbers

### DIFF
--- a/simple_python_with_bugs.py
+++ b/simple_python_with_bugs.py
@@ -2,6 +2,9 @@ def atoi(s: str) -> int:
     if not s:
         raise ValueError("Input string is empty")
 
+    if "." in s:
+        raise RuntimeError("Input string is a float, only integers are supported")
+
     num = 0
     start = 0
     negative = False


### PR DESCRIPTION
Throwing an exception if the input has a dot in it. Assuming the dot will indicate that it is a floating point number. 

Fixes #1 

